### PR TITLE
Fix Sanity Studio 500 error - change to force-dynamic

### DIFF
--- a/src/app/studio/[[...tool]]/page.tsx
+++ b/src/app/studio/[[...tool]]/page.tsx
@@ -10,7 +10,7 @@
 import { NextStudio } from 'next-sanity/studio'
 import config from '../../../../sanity.config'
 
-export const dynamic = 'force-static'
+export const dynamic = 'force-dynamic'
 
 export { metadata, viewport } from 'next-sanity/studio'
 


### PR DESCRIPTION
- Changed export const dynamic from 'force-static' to 'force-dynamic'
- Sanity Studio requires dynamic rendering to function properly
- This fixes the Internal Server Error 500 on /studio route